### PR TITLE
#1570 fix, hide the test-order/tests drop down

### DIFF
--- a/app/controllers/test_results_controller.rb
+++ b/app/controllers/test_results_controller.rb
@@ -38,11 +38,8 @@ class TestResultsController < ApplicationController
       format.html do
         @query["page_size"] = @page_size
         @query["offset"] = offset
-
         @filter["device.uuid"] = @devices.first.uuid if @devices.size == 1
-
         @can_create_encounter = check_access(@navigation_context.institution.sites, CREATE_SITE_ENCOUNTER).size > 0
-
         execute_query
       end
 

--- a/app/views/test_results/_filters.haml
+++ b/app/views/test_results/_filters.haml
@@ -20,7 +20,7 @@
       .advanced
 	  
         .row
-          .filter
+          .filter.nodisplay
             %label.block Display as
             = cdx_select name: "display_as", value: @display_as do |select|
               - select.item "test", "Tests"


### PR DESCRIPTION
Two url's will be used to get to test results so no need for this drop down .