### PR TITLE
Fixes #1604

### DIFF
--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -21,6 +21,7 @@ class Device < ActiveRecord::Base
   composed_of :ftp_info, mapping: FtpInfo.mapping('ftp_')
 
   attr_reader :plain_secret_key
+  attr_accessor :fake_username, :fake_password
 
   validates_uniqueness_of :uuid
   validates_presence_of :name

--- a/app/views/devices/_form.haml
+++ b/app/views/devices/_form.haml
@@ -1,4 +1,4 @@
-= form_for(@device) do |f|
+= form_for(@device, html: { autocomplete: 'off' }) do |f|
   = validation_errors @device
 
   .row
@@ -58,6 +58,10 @@
           = f.check_box :ftp_passive
           = f.label :ftp_passive, "&nbsp;".html_safe
         .col.pe-2= f.text_field :ftp_directory, placeholder: 'Folder'
+      .row{style: 'visibility:hidden; height: 1px'}
+        .col.pe-2= f.label :fake_username, 'Login'
+        .col.pe-2= text_field :fake_username, placeholder: 'Username', autocomplete: 'on'
+        .col.pe-2= f.password_field :fake_password, value: '', placeholder: 'Password', autocomplete: 'off'
       .row
         .col.pe-2= f.label :ftp_username, 'Login'
         .col.pe-2= f.text_field :ftp_username, placeholder: 'Username', autocomplete: 'off'


### PR DESCRIPTION
Some weird hack required after much digging into chrome behaviour. I had to resort to setting two fake username and password fields right before the ones that were being populated and then hiding them. This seemed to trick chrome into treating these as the autocomplete fields. It seems setting `autocomplete="off"` attribute alone was not enough.