### PR TITLE
#1859 added condition changes for test order status, also for the can…

### DIFF
--- a/app/assets/javascripts/components/encounter_show.js.jsx
+++ b/app/assets/javascripts/components/encounter_show.js.jsx
@@ -5,10 +5,16 @@ var EncounterShow = React.createClass({
       user_email= this.props.encounter["user"].email
     };
 
+    var disable_all_selects=false;
+    if (this.props.show_cancel==true || this.props.show_edit==false) {
+      disable_all_selects=true;
+    }
+
     return {
       user_email: user_email,
       error_messages:[],
-      requested_tests: this.props.requested_tests
+      requested_tests: this.props.requested_tests,
+      disable_all_selects: disable_all_selects
     };
   },
   submit_error: function(errorArray) {
@@ -172,7 +178,8 @@ var EncounterShow = React.createClass({
         </FlexFullRow>
 
         <div className="row">
-          <RequestedTestsIndexTable encounter={this.props.encounter} requested_tests={this.state.requested_tests} requested_by={this.props.requested_by}  status_types={this.props.status_types} edit={this.props.show_edit} onTestChanged={this.onTestChanged} />
+          <RequestedTestsIndexTable encounter={this.props.encounter} requested_tests={this.state.requested_tests} requested_by={this.props.requested_by}  
+            status_types={this.props.status_types} edit={this.props.show_edit} onTestChanged={this.onTestChanged} disable_all_selects={this.state.disable_all_selects} />
         </div>
 
         <br />

--- a/app/assets/javascripts/components/request_tests.js.jsx
+++ b/app/assets/javascripts/components/request_tests.js.jsx
@@ -49,6 +49,9 @@ var RequestedTestRow = React.createClass({
       <td><select key={this.state.test.id} onChange = {
           this.statusChanged
           }
+          disabled = {
+            this.props.disable_all_selects
+          }
           value={this.state.test.status}>{status_data.map(MakeItem)}</select></td>
     </tr>);
   }
@@ -97,7 +100,8 @@ var RequestedTestsList = React.createClass({
         <tbody>
           {this.props.requested_tests.map(function(requested_test) {
              return <RequestedTestRow key={requested_test.id} requested_test={requested_test} onTestChanged={this.onTestChanged}
-              encounter={this.props.encounter} requested_by={this.props.requested_by}  status_types={this.props.status_types} edit={this.props.edit}/>;
+              encounter={this.props.encounter} requested_by={this.props.requested_by}  status_types={this.props.status_types} 
+              edit={this.props.edit} disable_all_selects={this.props.disable_all_selects}  />;
           }.bind(this))}
         </tbody>
       </table>
@@ -111,6 +115,7 @@ var RequestedTestsIndexTable = React.createClass({
    },
   render: function() {
     return <RequestedTestsList requested_tests={this.props.requested_tests} encounter={this.props.encounter} onTestChanged={this.onTestChanged}
-              title={this.props.title} requested_by={this.props.requested_by} titleClassName="table-title" status_types={this.props.status_types} edit={this.props.edit} />
+              title={this.props.title} requested_by={this.props.requested_by} titleClassName="table-title" status_types={this.props.status_types} 
+              edit={this.props.edit} disable_all_selects={this.props.disable_all_selects} />
   }
 });

--- a/app/controllers/encounter_requested_tests_controller.rb
+++ b/app/controllers/encounter_requested_tests_controller.rb
@@ -3,19 +3,34 @@ class EncounterRequestedTestsController < ApplicationController
   def update
     error_text=Hash.new
     saved_ok = false
-    
-    encounter = Encounter.find(params[:id])  
     current_test=''
-    auth_ok = authorize_resource(encounter, UPDATE_ENCOUNTER)
+    encounter = Encounter.find(params[:id])  
+    auth_ok = authorize_resource(encounter, UPDATE_ENCOUNTER) 
     if auth_ok
-     requested_tests = params["requested_tests"]
+       requested_tests = params["requested_tests"]
+       count_all_tests_complete_rejected=0
+       set_status_in_progress=false
+
        requested_tests.each do |test|
          current_test = RequestedTest.find(test[1]["id"])
          saved_ok = current_test.update(status: test[1]["status"]) if current_test
+         
          if saved_ok==false
            error_text = current_test.errors.messages
+         elsif (RequestedTest.statuses[test[1]["status"]] == RequestedTest.statuses["complete"]) || 
+               (RequestedTest.statuses[test[1]["status"]] == RequestedTest.statuses["rejected"])
+           count_all_tests_complete_rejected += 1
+           set_status_in_progress = true
+         elsif RequestedTest.statuses[test[1]["status"]] == RequestedTest.statuses["inprogress"]
+           set_status_in_progress = true
          end
-       end 
+       end
+      
+       if (requested_tests.size > 0) && (requested_tests.size == count_all_tests_complete_rejected)
+         encounter.update!(status: Encounter.statuses["complete"])
+       elsif set_status_in_progress==true
+         encounter.update!(status: Encounter.statuses["inprogress"])
+       end
     end
     
     if auth_ok && saved_ok==true
@@ -23,7 +38,7 @@ class EncounterRequestedTestsController < ApplicationController
     else
       error_text[:error]='not authorised' if !auth_ok
       render json: error_text, status: :unprocessable_entity
-    end
-      
+    end    
   end
 end
+

--- a/app/controllers/encounters_controller.rb
+++ b/app/controllers/encounters_controller.rb
@@ -154,7 +154,7 @@ class EncountersController < ApplicationController
       referer_check = referer =~ /\/patients\/\d/
        if  referer_check != nil
         @show_edit_encounter=false
-        @show_cancel_encounter=true
+        @show_cancel_encounter=true if (@encounter != nil) && (Encounter.statuses[@encounter.status] != Encounter.statuses["inprogress"]) 
         @return_path_encounter=referer
       end
     end

--- a/app/models/requested_test.rb
+++ b/app/models/requested_test.rb
@@ -4,5 +4,5 @@ class RequestedTest < ActiveRecord::Base
   acts_as_paranoid
   
   validates_presence_of :name
-  enum status: [:pending, :inprogress, :rejected, :deleted]
+  enum status: [:pending, :inprogress, :complete, :rejected, :deleted]
 end

--- a/spec/controllers/encounter_requested_tests_controller.rb
+++ b/spec/controllers/encounter_requested_tests_controller.rb
@@ -22,9 +22,59 @@ describe EncounterRequestedTestsController  do
             }
           }
           
-      post :update,  id: encounter.id, requestedTests: jsondata
+      post :update,  id: encounter.id, requested_tests: jsondata
       test = RequestedTest.find(requested_test1.id)   
       expect(RequestedTest.statuses[test.status]).to eq RequestedTest.statuses["deleted"]
+      expect(Encounter.statuses[encounter.status]).to eq Encounter.statuses["pending"]
     end
+    
+    it "should update encounter status to completed ehen test status is complete" do
+      jsondata = 
+          {
+            "requested_tests" => {
+              "id" => requested_test1.id,
+              "status" => "complete"
+            }
+          }
+          
+      post :update,  id: encounter.id, requested_tests: jsondata
+      test = RequestedTest.find(requested_test1.id)   
+      updated_encounter = Encounter.find(encounter.id) 
+      expect(RequestedTest.statuses[test.status]).to eq RequestedTest.statuses["complete"]
+      expect(Encounter.statuses[updated_encounter.status]).to eq Encounter.statuses["complete"]
+    end
+    
+    it "should update encounter status to completed when test status is rejected" do
+      jsondata = 
+          {
+            "requested_tests" => {
+              "id" => requested_test1.id,
+              "status" => "rejected"
+            }
+          }
+          
+      post :update,  id: encounter.id, requested_tests: jsondata
+      test = RequestedTest.find(requested_test1.id)   
+      updated_encounter = Encounter.find(encounter.id) 
+      expect(RequestedTest.statuses[test.status]).to eq RequestedTest.statuses["rejected"]
+      expect(Encounter.statuses[updated_encounter.status]).to eq Encounter.statuses["complete"]
+    end
+    
+    it "should update encounter status to inprogress when test status is inprogress" do
+      jsondata = 
+          {
+            "requested_tests" => {
+              "id" => requested_test1.id,
+              "status" => "inprogress"
+            }
+          }
+          
+      post :update,  id: encounter.id, requested_tests: jsondata
+      test = RequestedTest.find(requested_test1.id)   
+      updated_encounter = Encounter.find(encounter.id) 
+      expect(RequestedTest.statuses[test.status]).to eq RequestedTest.statuses["inprogress"]
+      expect(Encounter.statuses[updated_encounter.status]).to eq Encounter.statuses["inprogress"]
+    end
+    
   end
 end

--- a/spec/features/encounter_spec.rb
+++ b/spec/features/encounter_spec.rb
@@ -160,6 +160,7 @@ describe "create encounter" do
       expect(page.encounter.patient.entity_id).to eq("1001")
       expect(page.encounter.samples.count).to eq(2)
       expect(page.encounter.requested_tests.count).to eq(4)
+      expect(page).to have_link("Update Test Order")
       expect(page.encounter.test_results.count).to eq(0)
     end
   end


### PR DESCRIPTION
in the cancel test order page you cannot change the test status fields in the drop down if the test order is running [in progress]

added logic set the test order status based in the test statuses.

added new states for encounter and requested_tests such as complete as they were mentioned in the stories.