### PR TITLE
A user should be taken to a different add results page based on the type of test

### DIFF
--- a/app/assets/javascripts/components/encounter_show.js.jsx
+++ b/app/assets/javascripts/components/encounter_show.js.jsx
@@ -24,7 +24,7 @@ var EncounterShow = React.createClass({
     $('body').scrollTop(0);
   },
   EncounterDeleteHandler: function() {
-    if (this.props.referer != nil) {
+    if (this.props.referer != null) {
       successUrl = this.props.referer;
     } else {
       successUrl = '/test_results?display_as=test_order';

--- a/app/assets/javascripts/components/request_tests.js.jsx
+++ b/app/assets/javascripts/components/request_tests.js.jsx
@@ -21,26 +21,44 @@ var RequestedTestRow = React.createClass({
     });
     this.props.onTestChanged(this.state.test);
   },
-  determineTestResultUrl(id,name) {
+  determineTestResultUrl(id,name, edit, is_associated) {
     var url_path;
+    var view_or_cancel_path;
+    var test_order_page_mode;
+    
+    if (edit == true) {
+      test_order_page_mode = 'edit';
+    } else {
+      test_order_page_mode = 'cancel';
+    }
+
+    if ((is_associated == true) && (edit == true)) {
+      view_or_cancel_path = '/edit?test_order_page_mode='+test_order_page_mode;
+    } else
+    if ((is_associated == true) || (edit == false)) {
+      view_or_cancel_path = '?test_order_page_mode='+test_order_page_mode;
+    } else {
+      view_or_cancel_path = '/new?test_order_page_mode='+test_order_page_mode;
+    }
+
     switch(name) {
       case 'xpertmtb':
-        url_path = "/requested_tests/"+id+"/xpert_result/new";
+        url_path = "/requested_tests/"+id+"/xpert_result"+view_or_cancel_path;
         break;
       case 'microscopy':
-        url_path = "/requested_tests/"+id+"/microscopy_result/new";
+        url_path = "/requested_tests/"+id+"/microscopy_result"+view_or_cancel_path;
         break;
       case 'drugsusceptibility':
-        url_path = "/requested_tests/"+id+"/dst_lpa_result/new";
+        url_path = "/requested_tests/"+id+"/dst_lpa_result"+view_or_cancel_path;
         break;
       case 'culture':
-        url_path = "/requested_tests/"+id+"/culture_result/new";
+        url_path = "/requested_tests/"+id+"/culture_result"+view_or_cancel_path;
         break;
       default:
         url_path=url_path = "/requested_tests/"+id+"/undefined_result";
     }
     return url_path;
-  },
+},
   render: function() {
     var encounter = this.props.encounter;
 
@@ -69,12 +87,25 @@ var RequestedTestRow = React.createClass({
     var test_result_url;
     var test_id=this.state.test.id;
     associated_patient_result = this.props.associated_tests_to_results.filter(function (el) {return el.requested_test_id == test_id;});
+
+    var is_associated;
     if (associated_patient_result.length == 0) {
-     test_result_url = this.determineTestResultUrl(this.state.test.id, this.state.test.name);
-     test_result_text="Add Result";
+      is_associated=false;
     } else {
+      is_associated=true;
+    }
+
+    if ((this.props.edit == true) && (is_associated == false)) {
+      test_result_url = this.determineTestResultUrl(this.state.test.id, this.state.test.name, this.props.edit, is_associated);
+      test_result_text = "Add Result";
+    } 
+    else if (is_associated == false) {
       test_result_url = "#";
-      test_result_text="Associated";
+      test_result_text = "";
+    }
+    else {
+      test_result_url = this.determineTestResultUrl(this.state.test.id, this.state.test.name, this.props.edit,is_associated);
+      test_result_text = "View Result";
     }
 
   return (
@@ -96,7 +127,6 @@ var RequestedTestRow = React.createClass({
           </select></td>
       <td><TextInputModal key={this.state.test.id} comment={this.state.test.comment} commentChanged={this.commentChanged} edit={this.props.edit}/></td>
       <td><a className="btn-add-link" href={test_result_url}>{test_result_text}</a></td>
-
       </tr>);
   }
 });

--- a/app/controllers/encounters_controller.rb
+++ b/app/controllers/encounters_controller.rb
@@ -153,7 +153,7 @@ class EncountersController < ApplicationController
     
     @return_path_encounter = test_results_path(display_as: 'test_order') if params['test_order_page_mode'] !=nil
     
-    if request.referer != nil
+    if request.referer
       referer = URI(request.referer).path
       referer_check = referer =~ /\/patients\/\d/
        if  (referer_check != nil) || (params['test_order_page_mode'] == 'cancel')

--- a/app/controllers/encounters_controller.rb
+++ b/app/controllers/encounters_controller.rb
@@ -147,16 +147,23 @@ class EncountersController < ApplicationController
   private
 
   def determine_referal
-    @show_edit_encounter=true
-    @show_cancel_encounter=false
-    @return_path_encounter=nil
+    @show_edit_encounter = true
+    @show_cancel_encounter = false
+    @return_path_encounter = nil
+    
+    @return_path_encounter = test_results_path(display_as: 'test_order') if params['test_order_page_mode'] !=nil
+    
     if request.referer != nil
       referer = URI(request.referer).path
       referer_check = referer =~ /\/patients\/\d/
-       if  referer_check != nil
+       if  (referer_check != nil) || (params['test_order_page_mode'] == 'cancel')
         @show_edit_encounter=false
-        @show_cancel_encounter=true if (@encounter != nil) && (Encounter.statuses[@encounter.status] != Encounter.statuses["inprogress"]) 
-        @return_path_encounter=referer
+        @show_cancel_encounter=true if (@encounter != nil) && (Encounter.statuses[@encounter.status] != Encounter.statuses["inprogress"])
+        if @encounter && @encounter.patient
+           @return_path_encounter=patient_path(@encounter.patient) 
+        else
+          @return_path_encounter=referer
+        end
       end
     end
   end
@@ -367,7 +374,7 @@ class EncountersController < ApplicationController
       json.(@encounter, :coll_sample_other)
       json.(@encounter, :diag_comment)
       json.(@encounter, :treatment_weeks)
-      json.(@encounter, :status)  
+      json.(@encounter, :status)
       json.(@encounter, :testdue_date)
       json.has_dirty_diagnostic @encounter.has_dirty_diagnostic?
       json.assays (@encounter_blender.core_fields[Encounter::ASSAYS_FIELD] || [])

--- a/app/controllers/patient_results_controller.rb
+++ b/app/controllers/patient_results_controller.rb
@@ -1,6 +1,6 @@
 class PatientResultsController < ApplicationController
 
-  before_filter :find_requested_test, :check_permissions
+  before_filter :find_requested_test, :check_permissions, :check_back_button_mode
 
   protected
 
@@ -10,5 +10,9 @@ class PatientResultsController < ApplicationController
 
   def check_permissions
     redirect_to(encounter_path(@requested_test.encounter), error: "You can't add test results to this test order") unless has_access?(TestResult, Policy::Actions::QUERY_TEST)
+  end
+
+  def check_back_button_mode
+    @return_page_mode = params['test_order_page_mode']
   end
 end

--- a/app/models/test_result_indexer.rb
+++ b/app/models/test_result_indexer.rb
@@ -39,7 +39,7 @@ class TestResultIndexer < EntityIndexer
     return {
       'test'        => test_fields(test_result),
       'device'      => device_fields(test_result.device),
- #     'location'    => location_fields(test_result.device.site.try(:location, ancestors: true)),
+      'location'    => location_fields(test_result.device.site.try(:location, ancestors: true)),
       'institution' => institution_fields(test_result.device.institution),
       'site'        => site_fields(test_result.device.site),
       'sample'      => sample_fields(test_result.sample),

--- a/app/models/test_result_indexer.rb
+++ b/app/models/test_result_indexer.rb
@@ -39,7 +39,7 @@ class TestResultIndexer < EntityIndexer
     return {
       'test'        => test_fields(test_result),
       'device'      => device_fields(test_result.device),
-      'location'    => location_fields(test_result.device.site.try(:location, ancestors: true)),
+ #     'location'    => location_fields(test_result.device.site.try(:location, ancestors: true)),
       'institution' => institution_fields(test_result.device.institution),
       'site'        => site_fields(test_result.device.site),
       'sample'      => sample_fields(test_result.sample),

--- a/app/views/culture_results/edit.haml
+++ b/app/views/culture_results/edit.haml
@@ -7,5 +7,5 @@
       .col-6
         %ul
           %li
-            = link_to I18n.t('views.back'), encounter_path(@requested_test.encounter), class: 'button new'
+            = link_to I18n.t('views.back'), encounter_path(@requested_test.encounter, :test_order_page_mode => @return_page_mode), class: 'button new'
     = render 'form'

--- a/app/views/culture_results/new.haml
+++ b/app/views/culture_results/new.haml
@@ -7,5 +7,5 @@
       .col-6
         %ul
           %li
-            = link_to I18n.t('views.back'), encounter_path(@requested_test.encounter), class: 'button new'
+            = link_to I18n.t('views.back'), encounter_path(@requested_test.encounter), :test_order_page_mode => @return_page_mode, class: 'button new'
     = render 'form'

--- a/app/views/culture_results/show.haml
+++ b/app/views/culture_results/show.haml
@@ -7,7 +7,7 @@
       .col-6
         %ul
           %li
-            = link_to I18n.t('views.back'), encounter_path(@requested_test.encounter), class: 'button new'
+            = link_to I18n.t('views.back'), encounter_path(@requested_test.encounter, :test_order_page_mode => @return_page_mode), class: 'button new'
     .order-details
       .panel
         .row

--- a/app/views/dst_lpa_results/edit.haml
+++ b/app/views/dst_lpa_results/edit.haml
@@ -7,5 +7,5 @@
       .col-6
         %ul
           %li
-            = link_to I18n.t('views.back'), encounter_path(@requested_test.encounter), class: 'button new'
+            = link_to I18n.t('views.back'), encounter_path(@requested_test.encounter, :test_order_page_mode => @return_page_mode), class: 'button new'
     = render 'form'

--- a/app/views/dst_lpa_results/new.haml
+++ b/app/views/dst_lpa_results/new.haml
@@ -7,5 +7,5 @@
       .col-6
         %ul
           %li
-            = link_to I18n.t('views.back'), encounter_path(@requested_test.encounter), class: 'button new'
+            = link_to I18n.t('views.back'), encounter_path(@requested_test.encounter, :test_order_page_mode => @return_page_mode), class: 'button new'
     = render 'form'

--- a/app/views/dst_lpa_results/show.haml
+++ b/app/views/dst_lpa_results/show.haml
@@ -7,7 +7,7 @@
       .col-6
         %ul
           %li
-            = link_to I18n.t('views.back'), encounter_path(@requested_test.encounter), class: 'button new'
+            = link_to I18n.t('views.back'), encounter_path(@requested_test.encounter, :test_order_page_mode => @return_page_mode), class: 'button new'
     .order-details
       .panel
         .row

--- a/app/views/microscopy_results/edit.haml
+++ b/app/views/microscopy_results/edit.haml
@@ -7,5 +7,5 @@
       .col-6
         %ul
           %li
-            = link_to I18n.t('views.back'), encounter_path(@requested_test.encounter), class: 'button new'
+            = link_to I18n.t('views.back'), encounter_path(@requested_test.encounter, :test_order_page_mode => @return_page_mode), class: 'button new'
     = render 'form'

--- a/app/views/microscopy_results/new.haml
+++ b/app/views/microscopy_results/new.haml
@@ -7,5 +7,5 @@
       .col-6
         %ul
           %li
-            = link_to I18n.t('views.back'), encounter_path(@requested_test.encounter), class: 'button new'
+            = link_to I18n.t('views.back'), encounter_path(@requested_test.encounter, :test_order_page_mode => @return_page_mode), class: 'button new'
     = render 'form'

--- a/app/views/microscopy_results/show.haml
+++ b/app/views/microscopy_results/show.haml
@@ -7,7 +7,7 @@
       .col-6
         %ul
           %li
-            = link_to I18n.t('views.back'), encounter_path(@requested_test.encounter), class: 'button new'
+            = link_to I18n.t('views.back'), encounter_path(@requested_test.encounter, :test_order_page_mode => @return_page_mode), class: 'button new'
     .order-details
       .panel
         .row

--- a/app/views/xpert_results/edit.haml
+++ b/app/views/xpert_results/edit.haml
@@ -7,5 +7,5 @@
       .col-6
         %ul
           %li
-            = link_to I18n.t('views.back'), encounter_path(@requested_test.encounter), class: 'button new'
+            = link_to I18n.t('views.back'), encounter_path(@requested_test.encounter, :test_order_page_mode => @return_page_mode), class: 'button new'
     = render 'form'

--- a/app/views/xpert_results/new.haml
+++ b/app/views/xpert_results/new.haml
@@ -7,5 +7,5 @@
       .col-6
         %ul
           %li
-            = link_to I18n.t('views.back'), encounter_path(@requested_test.encounter), class: 'button new'
+            = link_to I18n.t('views.back'), encounter_path(@requested_test.encounter, :test_order_page_mode => @return_page_mode), class: 'button new'
     = render 'form'

--- a/app/views/xpert_results/show.haml
+++ b/app/views/xpert_results/show.haml
@@ -7,7 +7,7 @@
       .col-6
         %ul
           %li
-            = link_to I18n.t('views.back'), encounter_path(@requested_test.encounter), class: 'button new'
+            = link_to I18n.t('views.back'), encounter_path(@requested_test.encounter, :test_order_page_mode => @return_page_mode), class: 'button new'
     .order-details
       .panel
         .row

--- a/spec/controllers/encounters_controller_spec.rb
+++ b/spec/controllers/encounters_controller_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe EncountersController, type: :controller, elasticsearch: true do
       expect(assigns[:associated_tests_to_results]).to eq([])
       expect(assigns[:show_edit_encounter]).to be_truthy
       expect(assigns[:show_cancel_encounter]).to be_falsy
-      expect(assigns[:return_path_encounter]).to include('display_as=test_order')
     end
 
     it "returns http forbidden if not allowed" do

--- a/spec/controllers/encounters_controller_spec.rb
+++ b/spec/controllers/encounters_controller_spec.rb
@@ -39,6 +39,9 @@ RSpec.describe EncountersController, type: :controller, elasticsearch: true do
       expect(response).to have_http_status(:success)
       expect(assigns[:can_update]).to be_falsy
       expect(assigns[:associated_tests_to_results]).to eq([])
+      expect(assigns[:show_edit_encounter]).to be_truthy
+      expect(assigns[:show_cancel_encounter]).to be_falsy
+      expect(assigns[:return_path_encounter]).to include('display_as=test_order')
     end
 
     it "returns http forbidden if not allowed" do

--- a/spec/features/encounter_spec.rb
+++ b/spec/features/encounter_spec.rb
@@ -121,7 +121,7 @@ describe "create encounter" do
       click_link('encountersave')
       click_link('encountersave')
     end
-
+    
     expect_page ShowEncounterPage do |page|
       expect(page.encounter.patient).to eq(patient)
       expect(page.encounter.samples.count).to eq(2)
@@ -169,9 +169,9 @@ describe "create encounter" do
     end
     
     expect_page NewCultureResultsPage do |page|
+      expect(page).to have_link('Back')   
       expect(page.has_content?('Add Culture Test Result')).to be true
     end
-    
   end
   
 


### PR DESCRIPTION
#1860 A user should be taken to a different add results page based on the type of test.

A parameter is passed to the result page to indicate if the test order page is in 'edit' or 'cancel' mode on page back.
The logic is started to get complicated [and could be done in a cleaner way if had more time]