### PR TITLE
#1891 test order rules to display/hide tests, fixed a status select bug.

### DIFF
--- a/app/assets/javascripts/components/request_tests.js.jsx
+++ b/app/assets/javascripts/components/request_tests.js.jsx
@@ -11,7 +11,7 @@ var RequestedTestRow = React.createClass({
     this.setState({
       test: temp_test
     });
-    this.props.onTestChanged(this.state.test);
+   this.props.onTestChanged(this.state.test);
   },
   commentChanged: function(new_comment) {
     var temp_test = this.state.test;
@@ -19,7 +19,7 @@ var RequestedTestRow = React.createClass({
     this.setState({
       test: temp_test
     });
-    this.props.onTestChanged(this.state.test);
+   this.props.onTestChanged(this.state.test);
   },
   determineTestResultUrl(id,name, edit, is_associated) {
     var url_path;
@@ -95,11 +95,16 @@ var RequestedTestRow = React.createClass({
       is_associated=true;
     }
 
-    if ((this.props.edit == true) && (is_associated == false)) {
+    if (this.state.test.status=='rejected') {
+      test_result_url = "#";
+      test_result_text = "";
+    } else 
+    if ((this.props.edit == true) && (is_associated == false) && 
+       ((this.state.test.status == 'pending') || (this.state.test.status == 'inprogress')) ) {
       test_result_url = this.determineTestResultUrl(this.state.test.id, this.state.test.name, this.props.edit, is_associated);
       test_result_text = "Add Result";
     } 
-    else if (is_associated == false) {
+    else if ( (is_associated == false) || ((this.props.cancel==true) && (this.state.test.status=='complete')) ) {
       test_result_url = "#";
       test_result_text = "";
     }
@@ -119,7 +124,7 @@ var RequestedTestRow = React.createClass({
             this.statusChanged
            }
           className="input-x-medium"
-          value={this.state.test.status}
+          defaultValue={this.state.test.status}
           disabled = {
             !this.props.edit
            }>


### PR DESCRIPTION
#1891 If a test status is set to reject then no result can be added or viewed,
#1859 If a test is set to pending or inprogress then a manual result can be added,If test is set to complete, then the lab tech can only view the result.
Fixed a test status <select> bug, there was a problem in the options used for reactjs whereby the status could not be correct set after changing.