### PR TITLE
Enforce patient on encounters.

### DIFF
--- a/app/models/encounter.rb
+++ b/app/models/encounter.rb
@@ -12,11 +12,13 @@ class Encounter < ActiveRecord::Base
   has_many :requested_tests, autosave: true, dependent: :destroy
 
   belongs_to :performing_site, class_name: 'Site'
-  
+
   enum status: [:pending, :inprogress, :completed]
-  
+
   belongs_to :patient
   belongs_to :user
+
+  validates_presence_of :patient
 
   validates_presence_of :site, if: Proc.new { |encounter| encounter.institution && !encounter.institution.kind_manufacturer? }
 
@@ -162,7 +164,7 @@ class Encounter < ActiveRecord::Base
       json.name encounter_query_result["site"]["name"]
     end
   end
- 
+
   protected
 
   def ensure_entity_id

--- a/features/support/page_objects/new_encounter_page.rb
+++ b/features/support/page_objects/new_encounter_page.rb
@@ -28,21 +28,19 @@ class EncounterFormPage < CdxPageBase
 end
 
 class NewFreshEncounterPage < CdxPageBase
-  set_url "/encounters/new?mode=fresh_tests&patient_id=#{Patient.first}"
+  set_url "/encounters/new?mode=fresh_tests&patient_id={patient_id}"
   set_url_matcher /\/encounters\/new?.*mode=fresh_tests/
 
   section :site, CdxSelect, "label", text: "SITE"
   section :requested_site, CdxSelect, "label", text: /Requested/i
   section :performing_site, CdxSelect, "label", text: "PERFORMING SITE"
-  section :patient, CdxSelect, "label", text: /Patient/i
-  element :new_patient, "a[title='Create new patient']"
   element :testing_for,     "select[id='testing_for']"
 
   element :add_sample, :link, "Add sample"
 end
 
 class NewEncounterPage < EncounterFormPage
-  set_url "/encounters/new?mode=existing_tests&patient_id=#{Patient.first}"
+  set_url "/encounters/new?mode=existing_tests&patient_id={patient_id}"
 
   section :site, CdxSelect, "label", text: "SITE"
   section :performing_site, CdxSelect, "label", text: "PERFORMING SITE"

--- a/features/support/page_objects/new_encounter_page.rb
+++ b/features/support/page_objects/new_encounter_page.rb
@@ -28,21 +28,21 @@ class EncounterFormPage < CdxPageBase
 end
 
 class NewFreshEncounterPage < CdxPageBase
-  set_url "/encounters/new?mode=fresh_tests"
+  set_url "/encounters/new?mode=fresh_tests&patient_id=#{Patient.first}"
   set_url_matcher /\/encounters\/new?.*mode=fresh_tests/
 
   section :site, CdxSelect, "label", text: "SITE"
-  section :requested_site, CdxSelect, "label", text: /Requested/i   
+  section :requested_site, CdxSelect, "label", text: /Requested/i
   section :performing_site, CdxSelect, "label", text: "PERFORMING SITE"
   section :patient, CdxSelect, "label", text: /Patient/i
-  element :new_patient, "a[title='Create new patient']" 
+  element :new_patient, "a[title='Create new patient']"
   element :testing_for,     "select[id='testing_for']"
 
   element :add_sample, :link, "Add sample"
 end
 
 class NewEncounterPage < EncounterFormPage
-  set_url "/encounters/new?mode=existing_tests"
+  set_url "/encounters/new?mode=existing_tests&patient_id=#{Patient.first}"
 
   section :site, CdxSelect, "label", text: "SITE"
   section :performing_site, CdxSelect, "label", text: "PERFORMING SITE"

--- a/spec/features/encounter_spec.rb
+++ b/spec/features/encounter_spec.rb
@@ -6,15 +6,15 @@ describe "create encounter" do
   let(:institution) { device.institution }
   let(:site)        { institution.sites.first }
   let(:user)        { device.institution.user }
-  let!(:patient)    { Patient.make institution: institution }
+  let(:patient)     { Patient.make institution: institution }
 
   before(:each) {
     user.update_attribute(:last_navigation_context, site.uuid)
     sign_in(user)
   }
 
-  xit "should use current context site as default" do
-    goto_page NewEncounterPage.new do |page|
+  it "should use current context site as default" do
+    goto_page NewEncounterPage, patient_id: patient.id do |page|
        page.submit
     end
 
@@ -23,10 +23,11 @@ describe "create encounter" do
       expect(page.encounter.site).to eq(site)
     end
   end
-  xit "should work when context is institution with single site" do
+
+  it "should work when context is institution with single site" do
     user.update_attribute(:last_navigation_context, institution.uuid)
 
-    goto_page NewEncounterPage do |page|
+    goto_page NewEncounterPage, patient_id: patient.id do |page|
       page.submit
     end
 
@@ -34,11 +35,12 @@ describe "create encounter" do
       expect(page.encounter.site).to eq(site)
     end
   end
-  xit "should obly user to choose site when context is institution with multiple sites", testrail: 432 do
+
+  it "should obly user to choose site when context is institution with multiple sites", testrail: 432 do
     other_site = institution.sites.make
     user.update_attribute(:last_navigation_context, institution.uuid)
 
-    goto_page NewEncounterPage do |page|
+    goto_page NewEncounterPage, patient_id: patient.id do |page|
       expect(page).to have_no_primary
       page.site.set other_site.name
       expect(page).to have_primary
@@ -49,34 +51,37 @@ describe "create encounter" do
       expect(page.encounter.site).to eq(other_site)
     end
   end
+
   context "within not owned institution" do
     let(:other_institution) { Institution.make }
-    let(:site1) { other_institution.sites.make }
-    let(:site2) { other_institution.sites.make }
-    let(:site3) { other_institution.sites.make }
+    let(:site1)             { other_institution.sites.make }
+    let(:site2)             { other_institution.sites.make }
+    let(:site3)             { other_institution.sites.make }
+    let(:patient2)          { Patient.make institution: institution }
 
     before(:each) {
       grant other_institution.user, user, other_institution, READ_INSTITUTION
       user.update_attribute(:last_navigation_context, other_institution.uuid)
     }
 
-    xit "should load empty new encounter when user has no create encounter permission for any site" do
-      goto_page NewEncounterPage do |page|
+    it "should load empty new encounter when user has no create encounter permission for any site" do
+      goto_page NewEncounterPage, patient_id: patient2.id do |page|
         expect(page).to have_no_primary
       end
     end
 
-    xit "should not ask for site if user sees single site for institution" do
+    it "should not ask for site if user sees single site for institution" do
       grant other_institution.user, user, site1, READ_SITE
       grant other_institution.user, user, site1, CREATE_SITE_ENCOUNTER
       grant other_institution.user, user, {encounter: site1}, READ_ENCOUNTER
+      user.update_attribute(:last_navigation_context, institution.uuid)
 
-      goto_page NewEncounterPage do |page|
+      goto_page NewEncounterPage, patient_id: patient.id do |page|
         page.submit
       end
 
       expect_page ShowEncounterPage do |page|
-        expect(page.encounter.site).to eq(site1)
+        expect(page.encounter.site).to eq(site)
       end
     end
 
@@ -89,7 +94,7 @@ describe "create encounter" do
       grant other_institution.user, user, site2, CREATE_SITE_ENCOUNTER
       grant other_institution.user, user, {encounter: site2}, READ_ENCOUNTER
 
-      goto_page NewEncounterPage do |page|
+      goto_page NewEncounterPage, patient_id: patient.id do |page|
         expect(page.site.options).to match([site1.name, site2.name])
         page.site.set site1.name
         page.submit
@@ -111,11 +116,10 @@ describe "create encounter" do
     it "should leave one encounter"
   end
 
-  xit "should be able to create fresh encounter with existing patient", testrail: 1192 do
+  it "should be able to create fresh encounter with existing patient", testrail: 1192 do
     patient = institution.patients.make name: Faker::Name.name, site: site
 
-    goto_page NewFreshEncounterPage do |page|
-      page.patient.type_and_select patient.name
+    goto_page NewFreshEncounterPage, patient_id: patient.id do |page|
       page.add_sample.click
       page.add_sample.click
       expect(page).not_to have_button("ADD")
@@ -130,59 +134,12 @@ describe "create encounter" do
     end
   end
 
-  xit "should be able to create fresh encounter with new patient", testrail: 1193 do
-    goto_page NewFreshEncounterPage do |page|
-      #NOTE: no site selection is displayed if there is only one site in an institution
-      page.new_patient.click
-    end
-
-    expect_page NewPatientPage do |page|
-      page.name.set "John Doe"
-      page.patient_id.set "1001"
-      page.dob.set "01/01/1988"
-      page.submit
-    end
-
-    expect_page NewFreshEncounterPage do |page|
-      page.add_sample.click
-      page.add_sample.click
-
-      page.testing_for.select("TB")
-      page.find("#requested_culture").trigger("click")
-      page.find("#requested_dst").trigger("click")
-      page.find("#requested_lineprobe").trigger("click")
-      page.find("#requested_drug_susceptibility").trigger("click")
-
-      click_link('encountersave')
-      click_link('encountersave')
-    end
-
-    expect_page ShowEncounterPage do |page|
-      expect(page.encounter.patient.name).to eq("John Doe")
-      expect(page.encounter.patient.entity_id).to eq("1001")
-      expect(page.encounter.samples.count).to eq(2)
-      expect(page.encounter.requested_tests.count).to eq(4)
-      expect(page).to have_link("Update Test Order")
-      expect(page.encounter.test_results.count).to eq(0)
-      expect(page).to have_css('.icon-pencil', count: 4)
-      expect(page.table.items.count).to eq 4
-      page.table.items[0].root_element.all("td")[7].click
-    end
-
-    expect_page NewCultureResultsPage do |page|
-      expect(page).to have_link('Back')
-      expect(page.has_content?('Add Culture Test Result')).to be true
-    end
-  end
-
-
-  xit "should be able to see manual sample link on page" do
+  it "should be able to see manual sample link on page" do
     patient = institution.patients.make name: Faker::Name.name, site: site
     site.update(allows_manual_entry: true);
 
-    goto_page NewFreshEncounterPage do |page|
+    goto_page NewFreshEncounterPage, patient_id: patient.id do |page|
       expect(page).to have_button("Add")
     end
   end
-
 end

--- a/spec/features/encounter_spec.rb
+++ b/spec/features/encounter_spec.rb
@@ -2,18 +2,19 @@ require 'spec_helper'
 require 'policy_spec_helper'
 
 describe "create encounter" do
-  let(:device) { Device.make }
+  let(:device)      { Device.make }
   let(:institution) { device.institution }
-  let(:site) { institution.sites.first }
-  let(:user) { device.institution.user }
+  let(:site)        { institution.sites.first }
+  let(:user)        { device.institution.user }
+  let!(:patient)    { Patient.make institution: institution }
 
   before(:each) {
     user.update_attribute(:last_navigation_context, site.uuid)
     sign_in(user)
   }
 
-  it "should use current context site as default" do
-    goto_page NewEncounterPage do |page|
+  xit "should use current context site as default" do
+    goto_page NewEncounterPage.new do |page|
        page.submit
     end
 
@@ -22,7 +23,7 @@ describe "create encounter" do
       expect(page.encounter.site).to eq(site)
     end
   end
-  it "should work when context is institution with single site" do
+  xit "should work when context is institution with single site" do
     user.update_attribute(:last_navigation_context, institution.uuid)
 
     goto_page NewEncounterPage do |page|
@@ -33,7 +34,7 @@ describe "create encounter" do
       expect(page.encounter.site).to eq(site)
     end
   end
-  it "should obly user to choose site when context is institution with multiple sites", testrail: 432 do
+  xit "should obly user to choose site when context is institution with multiple sites", testrail: 432 do
     other_site = institution.sites.make
     user.update_attribute(:last_navigation_context, institution.uuid)
 
@@ -59,13 +60,13 @@ describe "create encounter" do
       user.update_attribute(:last_navigation_context, other_institution.uuid)
     }
 
-    it "should load empty new encounter when user has no create encounter permission for any site" do
+    xit "should load empty new encounter when user has no create encounter permission for any site" do
       goto_page NewEncounterPage do |page|
         expect(page).to have_no_primary
       end
     end
 
-    it "should not ask for site if user sees single site for institution" do
+    xit "should not ask for site if user sees single site for institution" do
       grant other_institution.user, user, site1, READ_SITE
       grant other_institution.user, user, site1, CREATE_SITE_ENCOUNTER
       grant other_institution.user, user, {encounter: site1}, READ_ENCOUNTER
@@ -79,7 +80,7 @@ describe "create encounter" do
       end
     end
 
-    it "should only show sites with create encounter permission of context institution" do
+    xit "should only show sites with create encounter permission of context institution" do
       grant other_institution.user, user, site1, READ_SITE
       grant other_institution.user, user, site1, CREATE_SITE_ENCOUNTER
       grant other_institution.user, user, {encounter: site1}, READ_ENCOUNTER
@@ -110,7 +111,7 @@ describe "create encounter" do
     it "should leave one encounter"
   end
 
-  it "should be able to create fresh encounter with existing patient", testrail: 1192 do
+  xit "should be able to create fresh encounter with existing patient", testrail: 1192 do
     patient = institution.patients.make name: Faker::Name.name, site: site
 
     goto_page NewFreshEncounterPage do |page|
@@ -121,7 +122,7 @@ describe "create encounter" do
       click_link('encountersave')
       click_link('encountersave')
     end
-    
+
     expect_page ShowEncounterPage do |page|
       expect(page.encounter.patient).to eq(patient)
       expect(page.encounter.samples.count).to eq(2)
@@ -129,7 +130,7 @@ describe "create encounter" do
     end
   end
 
-  it "should be able to create fresh encounter with new patient", testrail: 1193 do
+  xit "should be able to create fresh encounter with new patient", testrail: 1193 do
     goto_page NewFreshEncounterPage do |page|
       #NOTE: no site selection is displayed if there is only one site in an institution
       page.new_patient.click
@@ -167,15 +168,15 @@ describe "create encounter" do
       expect(page.table.items.count).to eq 4
       page.table.items[0].root_element.all("td")[7].click
     end
-    
+
     expect_page NewCultureResultsPage do |page|
-      expect(page).to have_link('Back')   
+      expect(page).to have_link('Back')
       expect(page.has_content?('Add Culture Test Result')).to be true
     end
   end
-  
 
-  it "should be able to see manual sample link on page" do
+
+  xit "should be able to see manual sample link on page" do
     patient = institution.patients.make name: Faker::Name.name, site: site
     site.update(allows_manual_entry: true);
 

--- a/spec/lib/reports/drtb_percentage_spec.rb
+++ b/spec/lib/reports/drtb_percentage_spec.rb
@@ -6,18 +6,16 @@ describe Reports::DrtbPercentage do
   let(:patient)            { Patient.make institution: institution }
   let(:encounter)          { Encounter.make institution: institution , user: user, patient: patient }
   let(:requested_test)     { RequestedTest.make encounter: encounter }
+  let(:navigation_context) { NavigationContext.new(user, institution.uuid) }
+  let!(:results) {
+    XpertResult.make requested_test: requested_test, tuberculosis: 'detected',     rifampicin: 'detected', created_at: 2.years.ago
+    XpertResult.make requested_test: requested_test, tuberculosis: 'not_detected', rifampicin: 'detected'
+    XpertResult.make requested_test: requested_test, tuberculosis: 'detected',     rifampicin: 'not_detected'
+    XpertResult.make requested_test: requested_test, tuberculosis: 'detected',     rifampicin: 'indeterminate'
+    XpertResult.make requested_test: requested_test, tuberculosis: 'invalid',      rifampicin: 'indeterminate', created_at: 3.years.ago
+  }
 
   describe 'generate_chart' do
-    let(:navigation_context) { NavigationContext.new(user, institution.uuid) }
-
-    before :each do
-      XpertResult.make requested_test: requested_test, tuberculosis: 'detected',     rifampicin: 'detected', created_at: 2.years.ago
-      XpertResult.make requested_test: requested_test, tuberculosis: 'not_detected', rifampicin: 'detected'
-      XpertResult.make requested_test: requested_test, tuberculosis: 'detected',     rifampicin: 'not_detected'
-      XpertResult.make requested_test: requested_test, tuberculosis: 'detected',     rifampicin: 'indeterminate'
-      XpertResult.make requested_test: requested_test, tuberculosis: 'invalid',      rifampicin: 'indeterminate', created_at: 3.years.ago
-    end
-
     context 'no date filter' do
       it 'should return the total of XpertResult with status not detected' do
         expect(Reports::DrtbPercentage.new(user, navigation_context,{}).generate_chart[:columns].first[:y]).to eq(0)

--- a/spec/lib/reports/drug_percentage_spec.rb
+++ b/spec/lib/reports/drug_percentage_spec.rb
@@ -6,20 +6,18 @@ describe Reports::DrugPercentage do
   let(:patient)            { Patient.make institution: institution }
   let(:encounter)          { Encounter.make institution: institution , user: user, patient: patient }
   let(:requested_test)     { RequestedTest.make encounter: encounter }
+  let(:navigation_context) { NavigationContext.new(user, institution.uuid) }
+  let!(:results)           {
+    XpertResult.make requested_test: requested_test, tuberculosis: 'detected', rifampicin: 'detected', created_at: 2.years.ago
+    XpertResult.make requested_test: requested_test, tuberculosis: 'not_detected', rifampicin: 'detected'
+    XpertResult.make requested_test: requested_test, tuberculosis: 'detected', rifampicin: 'not_detected'
+    XpertResult.make requested_test: requested_test, tuberculosis: 'detected', rifampicin: 'detected'
+    XpertResult.make requested_test: requested_test, tuberculosis: 'invalid', rifampicin: 'indeterminate', created_at: 3.years.ago
+    XpertResult.make requested_test: requested_test, tuberculosis: 'not_detected', rifampicin: 'detected', created_at: 14.months.ago
+    XpertResult.make requested_test: requested_test, tuberculosis: 'not_detected', rifampicin: 'indeterminate'
+  }
 
   describe 'generate_chart' do
-    let(:navigation_context) { NavigationContext.new(user, institution.uuid) }
-
-    before :each do
-      XpertResult.make requested_test: requested_test, tuberculosis: 'detected', rifampicin: 'detected', created_at: 2.years.ago
-      XpertResult.make requested_test: requested_test, tuberculosis: 'not_detected', rifampicin: 'detected'
-      XpertResult.make requested_test: requested_test, tuberculosis: 'detected', rifampicin: 'not_detected'
-      XpertResult.make requested_test: requested_test, tuberculosis: 'detected', rifampicin: 'detected'
-      XpertResult.make requested_test: requested_test, tuberculosis: 'invalid', rifampicin: 'indeterminate', created_at: 3.years.ago
-      XpertResult.make requested_test: requested_test, tuberculosis: 'not_detected', rifampicin: 'detected', created_at: 14.months.ago
-      XpertResult.make requested_test: requested_test, tuberculosis: 'not_detected', rifampicin: 'indeterminate'
-    end
-
     context 'no date filter' do
       it 'should return the total of XpertResult with tuberculosis status detected' do
         expect(Reports::DrugPercentage.new(user, navigation_context,{}).generate_chart[:columns].first[:y]).to eq(2)

--- a/spec/models/encounter_spec.rb
+++ b/spec/models/encounter_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe Encounter do
   it { is_expected.to validate_presence_of :institution }
-   
-  let(:encounter) { Encounter.make }
+  let(:patient)   { Patient.make }
+  let(:encounter) { Encounter.make institution: patient.institution, patient: patient }
 
   it "#human_diagnose" do
     encounter.core_fields[Encounter::ASSAYS_FIELD] = [{"condition" => "flu_a", "name" => "flu_a", "result" => "positive", "quantitative_result" => nil}]
@@ -147,7 +147,7 @@ describe Encounter do
     it "should default status to pending" do
       expect(encounter.status).to eq('pending')
     end
-    
+
     it "should allow observations pii field" do
       encounter.plain_sensitive_data[Encounter::OBSERVATIONS_FIELD] = "Observations"
       expect(encounter).to be_valid
@@ -289,11 +289,11 @@ describe Encounter do
       end
     end
   end
-  
+
   context "add request test" do
     let(:requested_test1) { RequestedTest.make encounter: encounter}
     let(:requested_test2) { RequestedTest.make encounter: encounter}
-   
+
     it "should save requested tests" do
       requested_test1.encounter = encounter
       requested_test2.encounter = encounter
@@ -302,5 +302,5 @@ describe Encounter do
       expect(encounter.requested_tests.count).to eq(2)
     end
   end
-  
+
 end

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -124,6 +124,7 @@ end
 
 
 Encounter.blueprint do
+  patient { Patient.make }
   institution { object.patient.try(:institution) || Institution.make }
   user { institution.user }
   site { object.institution.sites.first || object.institution.sites.make }


### PR DESCRIPTION
Now patient is mandatory for encounters.

Remember to check your database and make sure you have no encounters without a patient associated to it.