### PR TITLE
#1873 Added validation when you delete a manifest

### DIFF
--- a/app/assets/javascripts/components/display_manifest.js.jsx.erb
+++ b/app/assets/javascripts/components/display_manifest.js.jsx.erb
@@ -1,0 +1,29 @@
+var DisplayManifest = React.createClass({
+  getInitialState: function() {
+    $( "#upload-new-file-id" ).addClass( "hidden" );
+    return {
+      display_manifest_class: ''
+    };
+  },
+  clickHandler: function() {
+    $( "#upload-new-file-id" ).removeClass( "hidden" );
+    this.setState( {
+    display_manifest_class: 'hidden'
+    });
+    document.getElementById('deleted_manifest_id').value = this.props.manifest_id.toString();
+  },
+  render: function() {
+    return (
+    <div className={this.state.display_manifest_class}>
+      <div className="file-upload">
+        <label className="input on">
+        <a href={this.props.manifest_path}>{this.props.manifest_filename}</a>
+        <a className="clear-label" onClick={this.clickHandler}>
+          <img src="<%= asset_url('ic-cross.png') %>"/>
+        </a>
+        </label>
+      </div>
+    </div>
+    );
+  }
+});

--- a/app/views/device_models/_form.haml
+++ b/app/views/device_models/_form.haml
@@ -22,13 +22,10 @@
           .col.pe-4
             = manifest_form.label :definition
           .col
+            %input#deleted_manifest_id{:name => "deleted_manifest", :type => "hidden", :value => ""}
             - if !@device_model.new_record? && @device_model.manifest.definition
-              .file-uploaded
-                %label.input.on
-                  = link_to @device_model.manifest.filename, manifest_device_model_path(@device_model)
-                  %a.clear-label{:href => "#"}
-                    = image_tag "ic-cross.png"
-            .upload-new-file
+              = react_component('DisplayManifest', manifest_id: @device_model.manifest.id, manifest_filename: @device_model.manifest.filename, manifest_path: manifest_device_model_path(@device_model) )
+            #upload-new-file-id.upload-new-file
               = manifest_form.file_field :definition, :class => "inputfile"
               %label{:for => 'device_model_manifest_attributes_definition'}
                 %span


### PR DESCRIPTION
#1873 Added validation when you delete a manifest,without uploading another an error message appears in you try and save the changes.
Due to the complex way of having a child model in the form and this child model can be replaced if you delete [hide the div] the manifest and upload [show the css] on the same page, it was cleaner to add a hidden form field to indicate if a manifest is deleted and do server side validation.
Initially tested a new delete action for the manifest but due to the device_model validations it was not best to just delete the manifest.
No json is used in the action call for this validation case, so just added a html response, if json is needed in the future we would need to decide how to add the error message to the API.