### PR TITLE
#1955 Device Not Reporting chart defaults to 366 days

### DIFF
--- a/lib/reports/devices_not_reporting.rb
+++ b/lib/reports/devices_not_reporting.rb
@@ -16,7 +16,7 @@ module Reports
             day_range      = ( Date.parse(options["date_range"]["start_time"]["lte"]) -  Date.parse(options["date_range"]["start_time"]["gte"]) ).to_i
             device_message = DeviceMessage.where(:device_id => device.id).where("created_at > ? and created_at < ?",options["date_range"]["start_time"]["lge"],options["date_range"]["start_time"]["lte"]).order(:created_at).first
           else
-            day_range      = (Date.parse(Time.now.strftime('%Y-%m-%d')) -  Date.parse(get_since)).to_i
+            day_range = (Date.parse(Time.now.strftime('%Y-%m-%d')) -  Date.parse(filter['since'])).to_i
             device_message = DeviceMessage.where(:device_id => device.id).where("created_at > ?", get_since).order(:created_at).first
           end
 
@@ -24,7 +24,13 @@ module Reports
             days_diff = ( (Time.now - (device_message.created_at) ) / (1.day)).round
             data << { label: device.name.truncate(13), value: days_diff }
           else
-            data << { label: device.name, value: day_range }
+            device_since_created = ( (Time.now - (device.created_at) ) / (1.day)).round
+            if device_since_created < day_range
+              device_days = device_since_created
+            else
+              device_days = day_range
+            end
+           data << { label: device.name, value: device_days}
           end
         end
       end


### PR DESCRIPTION
#1955  When adding a new device to site the Device Not Reporting chart defaults to 366 days for that device