### PR TITLE
fix for test orders header not displayed

### DIFF
--- a/app/policies/owner/institution.json.erb
+++ b/app/policies/owner/institution.json.erb
@@ -23,7 +23,8 @@
         "device?institution=<%= institution_id %>",
         "testResult?institution=<%= institution_id %>",
         "encounter?institution=<%= institution_id %>",
-        "alert?institution=<%= institution_id %>"
+        "alert?institution=<%= institution_id %>",
+        "pageHeader?institution=<%= institution_id %>"
       ],
       "action": "*",
       "delegable": true


### PR DESCRIPTION
Need to run: rake policy:update_roles, rake policy:calculate_computed when deployed.