### PR TITLE
2450-new-manifest-mapping

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -20,7 +20,7 @@ development:
 
 test: &test
   <<: *default
-  database: cdp_test
+  database: cdp_test<%= branch_spec %>
 
 production:
   <<: *default

--- a/db/seeds/manifests/genexpert_manifest.json
+++ b/db/seeds/manifests/genexpert_manifest.json
@@ -10,16 +10,26 @@
     }
   },
   "custom_fields" : {
+    "sample.xpert_notes" : {},
+    "test.xpert_patient_number"      : {},
+    "test.xpert_patient_family_name" : {},
+    "test.xpert_patient_given_name"  : {},
+    "test.xpert_patient_middle_name" : {}
   },
   "field_mapping": {
-    "sample.id" : { "lookup": "event.sample_ID" },
-    "test.site_user" : { "lookup": "event.system_user" },
-    "test.start_time" : { "lookup": "event.start_time" },
-    "test.end_time" : { "lookup": "event.end_time" },
-    "test.id" : { "lookup": "event.event_id" },
-    "test.error_code" : { "lookup": "event.error_code" },
-    "test.error_description" : { "lookup": "event.error_description" },
-    "test.name" : { "lookup": "event.assay_name" },
+    "sample.id"                      : { "lookup" : "event.sample_ID" },
+    "sample.xpert_notes"             : { "lookup" : "event.notes" },
+    "test.site_user"                 : { "lookup" : "event.system_user" },
+    "test.start_time"                : { "lookup" : "event.start_time" },
+    "test.end_time"                  : { "lookup" : "event.end_time" },
+    "test.id"                        : { "lookup" : "event.event_id" },
+    "test.error_code"                : { "lookup" : "event.error_code" },
+    "test.error_description"         : { "lookup" : "event.error_description" },
+    "test.name"                      : { "lookup" : "event.assay_name" },
+    "test.xpert_patient_number"      : { "lookup" : "event.patient_ID" },
+    "test.xpert_patient_family_name" : { "lookup" : "event.family_name" },
+    "test.xpert_patient_given_name"  : { "lookup" : "event.given_name" },
+    "test.xpert_patient_middle_name" : { "lookup" : "event.middle_name" },
     "test.type" : { "case" : [
       { "lookup": "event.test_type" },
       [


### PR DESCRIPTION
https://find.plan.io/issues/2450

I thought I had submitted this already.

Mapping 'event.patient_ID' and 'event.notes', to custom fields on the test order (as xpert_patient_number) and the sample (as xpert_number). Field names can change easily if requested.

