### PR TITLE
Fixes missing token in invitation email

### DIFF
--- a/cdx_core/app/mailers/invitation_mailer.rb
+++ b/cdx_core/app/mailers/invitation_mailer.rb
@@ -1,10 +1,10 @@
 class InvitationMailer < ApplicationMailer
-  def invite_message(user, role, message)
+  def invite_message(user, role, message, token)
     @user = user
     @role = role
-    @token = user.raw_invitation_token
+    @token = token
     @message = message
 
-    mail(:to => @user.email, :subject => I18n.t("invitation_mailer.subject"))
+    mail(to: @user.email, subject: I18n.t('invitation_mailer.subject'))
   end
 end

--- a/cdx_core/app/middleware/persistence/users.rb
+++ b/cdx_core/app/middleware/persistence/users.rb
@@ -32,7 +32,8 @@ class Persistence::Users
     end
     user.invitation_sent_at = Time.now.utc
     user.invited_by_id      = @current_user.id
-    InvitationMailer.delay.invite_message(user, role, message)
+    token = user.raw_invitation_token
+    InvitationMailer.delay.invite_message(user, role, message, token)
   end
 
   def add_role(user, role)


### PR DESCRIPTION
For some reason, sending email asyncrounsly loses the activation token
in the invitation email. Not sure this is the perfect fix, but should
suffice for now.