### PR TITLE
Bumping doorkeeper version..

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ gem 'encryptor'
 
 gem 'dotiw'
 gem 'rails-i18n', '~> 4.0.0'
-gem 'doorkeeper'
+gem 'doorkeeper', '~> 4.2.0'
 gem 'bettertabs'
 
 gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,8 +215,8 @@ GEM
     diff-lcs (1.2.5)
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
-    doorkeeper (3.0.1)
-      railties (>= 3.2)
+    doorkeeper (4.2.0)
+      railties (>= 4.2)
     dotiw (3.0.1)
       actionpack (>= 3)
       i18n
@@ -650,7 +650,7 @@ DEPENDENCIES
   devise (~> 3.5.5)
   devise_invitable
   devise_security_extension!
-  doorkeeper
+  doorkeeper (~> 4.2.0)
   dotiw
   elasticsearch
   encryptor


### PR DESCRIPTION
Doorkeeper failed to implement OAuth 2.0 Token Revocation (RFC 7009) in
the following ways:

-(1) Public clients making valid, unauthenticated calls to revoke a token
would not have their token revoked
-(2) Requests were not properly authenticating the client credentials but
were, instead, looking at the access token in a second location
-(3) Because of 2, the requests were also not authorizing confidential
clients' ability to revoke a given token. It should only revoke tokens
that belong to it.