### PR TITLE
add counts to aggregation messages & notification conditions validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,7 +107,11 @@ source 'https://rails-assets.org' do
   gem 'rails-assets-urijs'
 end
 
+# SMS library
 gem 'twilio-ruby', '~> 4.11.1'
+
+# Keep track of changes when multiple saves happen within a transaction
+gem 'ar_transaction_changes'
 
 group :development, :test do
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,8 @@ GEM
       railties (>= 3.2.8)
     addressable (2.3.8)
     ansi (1.5.0)
+    ar_transaction_changes (1.1.0)
+      activerecord (>= 3.0, < 6.0, != 4.2.3)
     arel (6.0.3)
     awesome_nested_set (3.0.2)
       activerecord (>= 4.0.0, < 5)
@@ -619,6 +621,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport-decorators (~> 2.1)
+  ar_transaction_changes
   awesome_nested_set (~> 3.0.0.rc.3)
   aws-sdk (~> 1.6)
   barby

--- a/cdx_core/Gemfile
+++ b/cdx_core/Gemfile
@@ -58,6 +58,9 @@ gem 'sidekiq-cron'
 # SMS library
 gem 'twilio-ruby', '~> 4.11.1'
 
+# Keep track of changes when multiple saves happen within a transaction
+gem 'ar_transaction_changes'
+
 group :development do
   gem 'letter_opener'
   gem 'letter_opener_web'

--- a/cdx_core/Gemfile.lock
+++ b/cdx_core/Gemfile.lock
@@ -77,6 +77,8 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
+    ar_transaction_changes (1.1.0)
+      activerecord (>= 3.0, < 6.0, != 4.2.3)
     arel (6.0.3)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
@@ -488,6 +490,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  ar_transaction_changes
   barby
   base58
   better_errors

--- a/cdx_core/app/mailers/notification_mailer.rb
+++ b/cdx_core/app/mailers/notification_mailer.rb
@@ -7,9 +7,10 @@ class NotificationMailer < ApplicationMailer
     mail(to: email_address, subject: I18n.t('middleware.notifications.gateway.email.subject'))
   end
 
-  def aggregated(email_address, body)
+  def aggregated(email_address, notice_group, gateway)
     @email_address = email_address
-    @body    = body
+    @notice_group  = notice_group
+    @gateway       = gateway
 
     mail(to: email_address, subject: I18n.t('middleware.notifications.gateway.email.subject'))
   end

--- a/cdx_core/app/middleware/notifications/gateway/sms.rb
+++ b/cdx_core/app/middleware/notifications/gateway/sms.rb
@@ -5,7 +5,7 @@ module Notifications
 
       def self.aggregated(phone_number, aggregated_count, aggregated_at, body = nil)
         gateway = new(phone_number: phone_number)
-        gateway.body = (body || I18n.t('middleware.notifications.gateway.sms.aggregated_body', count: aggregated_count, date: I18n.l(aggregated_at, format: :long)))
+        gateway.body = [body, I18n.t('middleware.notifications.gateway.sms.aggregated_body', count: aggregated_count, date: I18n.l(aggregated_at, format: :long))].join("\n")
         gateway.send_message
       end
 

--- a/cdx_core/app/models/concerns/notification_observer.rb
+++ b/cdx_core/app/models/concerns/notification_observer.rb
@@ -1,5 +1,6 @@
 module NotificationObserver
   extend ActiveSupport::Concern
+  include ArTransactionChanges
 
   class_methods do
     def notification_observe_field(model_field, options = {})
@@ -28,8 +29,21 @@ module NotificationObserver
       self.class._has_observable_fields?
     end
 
+    def _changed_attributes
+      @_changed_attributes =
+        previous_changes.inject({}) do |c, (k, v)|
+          if transaction_changed_attributes.has_key?(k) && transaction_changed_attributes[k].blank?
+            { k => [transaction_changed_attributes[k], self.send(k)] }
+          elsif new_value = transaction_changed_attributes[k]
+            { k => [new_value, v[1]] }
+          else
+            { k => v }
+          end.merge(c)
+        end
+    end
+
     def _fire_check_notification_job
-      selected_changed_attributes = previous_changes.select { |k, _v| self.class._notification_observed_fields.include?(k.to_sym) }
+      selected_changed_attributes = _changed_attributes.select { |k, _v| self.class._notification_observed_fields.include?(k.to_sym) }
       !selected_changed_attributes.empty? &&
         CheckNotificationJob.perform_async(self.class, id, selected_changed_attributes)
     end

--- a/cdx_core/app/models/notification.rb
+++ b/cdx_core/app/models/notification.rb
@@ -39,7 +39,7 @@ class Notification < ActiveRecord::Base
   has_many :roles,   through: :notification_roles,   class_name: '::Role'
   has_many :users,   through: :notification_users,   class_name: '::User'
 
-  has_many :notification_conditions, class_name: 'Notification::Condition'
+  has_many :notification_conditions, class_name: 'Notification::Condition', validate: true
   has_many :notification_recipients, class_name: 'Notification::Recipient'
   has_many :notification_statuses,   class_name: 'Notification::Status'
   has_many :notification_notices,    class_name: 'Notification::Notice'

--- a/cdx_core/app/views/notification_mailer/aggregated.text.erb
+++ b/cdx_core/app/views/notification_mailer/aggregated.text.erb
@@ -1,1 +1,7 @@
-<%= @body %>
+<% for message, count in @notice_group.email_messages %>
+<%= message %>
+- <%= pluralize(count, Notification.model_name.human) %>
+
+<% end %>
+
+<%= I18n.t('middleware.notifications.gateway.email.aggregated_body', count: @gateway.aggregated_count, date: I18n.l(@gateway.aggregated_at, format: :long)) %>

--- a/cdx_core/lib/tasks/alerts.rake
+++ b/cdx_core/lib/tasks/alerts.rake
@@ -25,7 +25,6 @@ task remove_alerts_from_policies: :environment do
   end
 
   ComputedPolicy.where(resource_type: 'alert').update_all(resource_type: 'notification')
-
 end
 
 task migrate_alerts_conditions: :environment do
@@ -56,5 +55,14 @@ task migrate_alerts_conditions: :environment do
         end
       end
     end
+  end
+end
+
+task convert_notice_groups: :environment do
+  Notification::NoticeGroup.update_all(email_messages: nil, sms_messages: nil)
+
+  Notification::NoticeGroup.all.each do |group|
+    group.send(:collate_notification_messages)
+    group.save!
   end
 end

--- a/cdx_core/spec/dummy/db/schema.rb
+++ b/cdx_core/spec/dummy/db/schema.rb
@@ -687,6 +687,7 @@ ActiveRecord::Schema.define(version: 20161106181141) do
     t.boolean  "skip_ssc_validation",                   default: false
     t.string   "etb_patient_id",          limit: 255
     t.string   "vtm_patient_id",          limit: 255
+    t.string   "nationality",             limit: 255
   end
 
   add_index "patients", ["birth_date_on"], name: "index_patients_on_birth_date_on", using: :btree

--- a/spec/mailers/previews/notification_mailer_preview.rb
+++ b/spec/mailers/previews/notification_mailer_preview.rb
@@ -1,0 +1,8 @@
+class NotificationPreview < ActionMailer::Preview
+  # Accessible from http://localhost:3000/rails/mailers/notifier/welcome
+  def aggregated
+    @notice_group = Notification::NoticeGroup.first
+
+    NotificationMailer.aggregated('test@example.com', @notice_group, Notifications::Gateway::Email.new(aggregated_count: @notice_group.notification_notices.count, aggregated_at: Time.now))
+  end
+end


### PR DESCRIPTION
To clear up the serialisation change the following needs to be run after deployment;

`rake convert_notice_groups`