### PR TITLE
remove observer from AssayResult

### DIFF
--- a/cdx_core/app/models/assay_result.rb
+++ b/cdx_core/app/models/assay_result.rb
@@ -4,9 +4,5 @@ class AssayResult < ActiveRecord::Base
 
   belongs_to :assayable, polymorphic: true
 
-  notification_observe_field :condition
-  notification_observe_field :result
-  notification_observe_field :quantitative_result
-
   serialize :assay_data, Hash
 end

--- a/cdx_core/app/models/notification/condition.rb
+++ b/cdx_core/app/models/notification/condition.rb
@@ -7,7 +7,6 @@ class Notification::Condition < ActiveRecord::Base
     DstLpaResult
     MicroscopyResult
     XpertResult
-    AssayResult
   )
 
   # Relationships

--- a/cdx_core/spec/jobs/check_notification_job_spec.rb
+++ b/cdx_core/spec/jobs/check_notification_job_spec.rb
@@ -19,7 +19,7 @@ describe CheckNotificationJob do
       end
     end
 
-    context 'when AssayResult' do
+    xcontext 'when AssayResult' do
       before { AssayResult.make }
 
       it do

--- a/cdx_core/spec/middleware/notifications/assay_result_lookup_spec.rb
+++ b/cdx_core/spec/middleware/notifications/assay_result_lookup_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Notifications::AssayResultLookup do
+xdescribe Notifications::AssayResultLookup do
   let!(:institution)   { Institution.make }
   let!(:test_result)   { TestResult.make(institution: institution, device: Device.make(site: Site.make(institution: institution))) }
 


### PR DESCRIPTION
Avoid firing off thousands of jobs when devices input historical data.