### PR TITLE
allow cmnd to be blank in vn / remove encounter alert link

### DIFF
--- a/cdx_core/app/views/encounters/show.html.haml
+++ b/cdx_core/app/views/encounters/show.html.haml
@@ -17,11 +17,6 @@
   rejectReasons: FeedbackMessages::Presenter.reject_reasons(@encounter.institution),
   authenticityToken: form_authenticity_token)
 
-.row
-  .col-6
-    = link_to I18n.t('encounters.show.create_notification'), new_alert_group_path(encounter_id: @encounter.id), class: 'btn-primary addalertbut'
-
-
 - if @encounter.status == 'new'
   .row
     .col

--- a/cdx_vietnam/Gemfile
+++ b/cdx_vietnam/Gemfile
@@ -56,6 +56,7 @@ gem 'sinatra'
 gem 'sidekiq-cron'
 gem 'cdx_core', path: '../'
 gem 'activesupport-decorators', '~> 2.1'
+gem 'ar_transaction_changes'
 
 group :development do
   gem 'letter_opener'

--- a/cdx_vietnam/Gemfile.lock
+++ b/cdx_vietnam/Gemfile.lock
@@ -82,6 +82,8 @@ GEM
     activesupport-decorators (2.1.1)
       railties (>= 3.2.8)
     addressable (2.4.0)
+    ar_transaction_changes (1.1.0)
+      activerecord (>= 3.0, < 6.0, != 4.2.3)
     arel (6.0.3)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
@@ -487,6 +489,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport-decorators (~> 2.1)
+  ar_transaction_changes
   barby
   base58
   better_errors

--- a/cdx_vietnam/app/models/patient_decorator.rb
+++ b/cdx_vietnam/app/models/patient_decorator.rb
@@ -1,6 +1,8 @@
 # Vietnam specific logic for patients
 class Patient < ActiveRecord::Base
-  validates :social_security_code, length: { in: 9..15, message: :cmnd_validation }, unless: Proc.new { |patient| patient.skip_ssc_validation }
+  validates :social_security_code, length: { in: 9..15, message: :cmnd_validation },
+                                   unless: proc { |patient| patient.skip_ssc_validation },
+                                   allow_blank: true
 
   def display_patient_id
     'VPN' << id.to_s.rjust(6, '0')

--- a/cdx_vietnam/config/locales/views/cdx_vietnam/patients.en.yml
+++ b/cdx_vietnam/config/locales/views/cdx_vietnam/patients.en.yml
@@ -4,7 +4,7 @@ en:
       social_security_code: Social Security ID
       vitimes_id: Vitimes/eTB Manager Log ID
       vitimes_id_tooltip: Enter the Vitimes Log ID
-      wrong_social_security_number: "Your input does not confirm to the validation criteria (Min 9 characters Max 15). Do you want to save anyway?"
+      wrong_social_security_number: "Your input does not conform to the validation criteria (Min 9 characters Max 15). Do you want to save anyway?"
       social_security_code_tooltip: "Social Security ID (Min 9 characters Max 15)"
       wrong_medical_insurance_num: This is not a valid Medical Insurance Number (2 characters followed by 13 digits). Do you still wish to continue?
       nationality: Nationality

--- a/cdx_vietnam/spec/models/patient_spec.rb
+++ b/cdx_vietnam/spec/models/patient_spec.rb
@@ -19,6 +19,16 @@ RSpec.describe Patient, type: :model do
         patient.social_security_code = SecureRandom.hex(16)
         expect(patient).to be_invalid
       end
+
+      it 'is nil' do
+        patient.social_security_code = nil
+        expect(patient).to be_valid
+      end
+
+      it 'is blank' do
+        patient.social_security_code = ''
+        expect(patient).to be_valid
+      end
     end
 
     context 'should not be validated' do


### PR DESCRIPTION
- Remove Create Alert from this Test Order button.
- Added `allow_blank` to CMND validation in `cdx_vietnam`