### PR TITLE
CMND is no longer required

### DIFF
--- a/cdx_vietnam/app/middleware/middleware/integration/etb_scraper.rb
+++ b/cdx_vietnam/app/middleware/middleware/integration/etb_scraper.rb
@@ -286,7 +286,6 @@ module Integration
 
         check_key 'name', params
         check_key 'bdq_id', params
-        check_key 'national_id_number', params
         check_key 'gender', params
         check_key 'age', params
         check_key 'registration_address1', params


### PR DESCRIPTION
CMND (national id number) is no longer required for a patient to be copied to ETB Manager