### PR TITLE
linking / patient form fixes

### DIFF
--- a/cdx_core/app/middleware/xpert_results/finder.rb
+++ b/cdx_core/app/middleware/xpert_results/finder.rb
@@ -7,6 +7,8 @@ module XpertResults
           xpert_result = sample_identifier.sample.encounter.xpert_results.where('patient_results.sample_identifier_id IS NULL').first
           return [xpert_result, sample_identifier] if xpert_result.present?
         end
+
+        nil
       end
     end
   end

--- a/cdx_core/app/models/sample_identifier.rb
+++ b/cdx_core/app/models/sample_identifier.rb
@@ -14,7 +14,7 @@ class SampleIdentifier < ActiveRecord::Base
   acts_as_paranoid
 
   def phantom?
-    entity_id.nil?
+    entity_id.nil? && cpd_id_sample.nil?
   end
 
   def not_phantom?

--- a/cdx_vietnam/app/middleware/xpert_results/vietnam_importer.rb
+++ b/cdx_vietnam/app/middleware/xpert_results/vietnam_importer.rb
@@ -7,6 +7,10 @@ module XpertResults
         update_sample_identifier(@sample_identifier, parsed_message)
       end
 
+      def valid_gene_xpert_result_and_sample?(device, parsed_message)
+        super(device, parsed_message) && status_from_parsed_message(parsed_message['test']) == 'success'
+      end
+
       protected
 
       def update_sample_identifier(sample_identifier, parsed_message)
@@ -21,6 +25,11 @@ module XpertResults
         notes = sample_data['custom']['xpert_notes']
         any_match = notes.match(/CDPSAMPLE(.*)CDPSAMPLE/i)
         any_match ? any_match[1] : nil
+      end
+
+      def status_from_parsed_message(test_data)
+        return '' unless test_data['core'].present? && test_data['core']['status'].present?
+        test_data['core']['status']
       end
 
       def patient_number_from_parsed_message(test_data)

--- a/cdx_vietnam/app/views/addresses/_country_select_form.haml
+++ b/cdx_vietnam/app/views/addresses/_country_select_form.haml
@@ -1,1 +1,1 @@
-= address_form.country_select( 'country', priority_countries: ['VN','KH','CN','LA','TH'], class: 'input-large' )
+= address_form.country_select( 'country', priority_countries: ['VN','KH','CN','LA','TH'], class: 'input-large', prompt: true )

--- a/cdx_vietnam/app/views/addresses/_region_form.html.haml
+++ b/cdx_vietnam/app/views/addresses/_region_form.html.haml
@@ -1,1 +1,1 @@
-= address_form.select :state, Address.regions.map(&:reverse)
+= address_form.select(:state, Address.regions.map(&:reverse), prompt: true)

--- a/cdx_vietnam/spec/middleware/importer/single_message_processor_spec.rb
+++ b/cdx_vietnam/spec/middleware/importer/single_message_processor_spec.rb
@@ -126,7 +126,15 @@ describe Importer::SingleMessageProcessor do
     context 'it should generate an orphan result ' do
       before :each do
         xpert_result.update_attribute(:result_status, 'allocated')
+        parsed_message['test']['core']['status'] = 'success'
         Device.any_instance.stub(:model_is_gen_expert?).and_return(true)
+      end
+
+      it 'when parsed_message.status is not a success' do
+        parsed_message['test']['core']['status'] = 'no_result'
+        described_class.new(device_message_processor, parsed_message).process
+
+        expect(TestResult.first.sample_identifier.entity_id).to eq('12345')
       end
 
       it 'when notes field is empty' do

--- a/cdx_vietnam/spec/middleware/xpert_results/vietnam_importer_spec.rb
+++ b/cdx_vietnam/spec/middleware/xpert_results/vietnam_importer_spec.rb
@@ -129,5 +129,13 @@ describe XpertResults::VietnamImporter do
         expect(described_class.valid_gene_xpert_result_and_sample?(device, parsed_message)).to be true
       end
     end
+
+    context 'valid device, xpert result, but no result from device' do
+      it 'should return false' do
+        parsed_message['test']['core']['status'] = 'no_result'
+        device.stub(:model_is_gen_expert?).and_return(true)
+        expect(described_class.valid_gene_xpert_result_and_sample?(device, parsed_message)).to be false
+      end
+    end
   end
 end

--- a/cdx_vietnam/spec/support/blueprints.rb
+++ b/cdx_vietnam/spec/support/blueprints.rb
@@ -4,6 +4,7 @@ require 'faker'
 Patient.blueprint do
   name Faker::Name.name
   institution
+  site  { Site.make(institution: object.institution) }
   is_phantom { false }
   social_security_code { Faker::Number.hexadecimal(11) }
   plain_sensitive_data {
@@ -28,5 +29,4 @@ IntegrationLog.blueprint do
 end
 
 PatientResult.blueprint do
-
 end


### PR DESCRIPTION
- If there is a sample_id on an encounter, but no valid sample_identifier to link to. Don't raise an error and fail the device message processing. Create an orphan.
- Don't link device_messages that are 'error', 'no_result', or 'invalid'.
- Don't default region/country on the patient form.
