### PR TITLE
lower sidekiq concurrency to 5 & raise mysql connection pool to 10

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -8,7 +8,7 @@
 default: &default
   adapter: mysql2
   encoding: utf8
-  pool: 5
+  pool: 10
   host: <%= ENV["MYSQL_HOST"] %>
   username: <%= ENV["MYSQL_USERNAME"] || "root" %>
   password: <%= ENV["MYSQL_PASSWORD"] || "" %>

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,4 @@
 ---
 :verbose: true
 :logfile: ./log/sidekiq.log
-:concurrency:  25
+:concurrency:  5


### PR DESCRIPTION
We have one job that runs every 1 minute.
We have one job that runs every 15 minutes.
We have the check notification job that runs whenever statuses or results are updated.
We have the integration jobs that run whenever certain test order statuses are hit.
We have one job that runs every hour.
We have one job that runs every month.
We have the user registration/forgot password email jobs.

I don't see an issue with a concurrency of 5 for jobs. If we get really stuck, we can divide the jobs into queues.

------

Currently, puma has one worker, it has 1-6 threads. The MySQL connection pool is set to 5.

The puma threads needs to be set to at least the same as the mysql connection pool. Yet this doesn't account for external connections in tasks, or sidekiq.

So we need to actually raise the mysql connection pool limit, or lower puma and sidekiq considerably.

Keep in mind that puma defaults to 1 thread, and spins up to 6... which is why we are not seeing more errors.